### PR TITLE
Fix ToHashSet not existing in net452

### DIFF
--- a/Code/Madhunt/ArenaOption.cs
+++ b/Code/Madhunt/ArenaOption.cs
@@ -15,7 +15,7 @@ namespace Celeste.Mod.Madhunt {
 
         public ArenaOption(EntityData data, Vector2 offset) {
             this.data = data;
-            this.switchIDs = data.Attr("switchIDs").Split(new[]{','}).Select(s => int.Parse(s)).ToHashSet();
+            this.switchIDs = new HashSet<int>(data.Attr("switchIDs").Split(new[]{','}).Select(s => int.Parse(s)));
         }
 
         public bool CanChooseOption(StartSwitch sSwitch) => switchIDs.Contains(sSwitch.SwitchID);

--- a/Code/Madhunt/Manager.cs
+++ b/Code/Madhunt/Manager.cs
@@ -277,10 +277,10 @@ namespace Celeste.Mod.Madhunt {
 
                 if(doReset) {
                     roundState.oldDashes = ses.Dashes;
-                    roundState.oldFlags = ses.Flags.ToHashSet();
-                    roundState.oldLevelFlags = ses.LevelFlags.ToHashSet();
-                    roundState.oldDoNotLoad = ses.DoNotLoad.ToHashSet();
-                    roundState.oldKeys = ses.Keys.ToHashSet();
+                    roundState.oldFlags = ses.Flags;
+                    roundState.oldLevelFlags = ses.LevelFlags;
+                    roundState.oldDoNotLoad = ses.DoNotLoad;
+                    roundState.oldKeys = ses.Keys;
                     ses.Keys.Clear();
                     if(Celeste.Scene.Tracker.GetEntity<Player>() is Player player) player.Leader.LoseFollowers();
                 }

--- a/Code/Madhunt/Manager.cs
+++ b/Code/Madhunt/Manager.cs
@@ -277,10 +277,10 @@ namespace Celeste.Mod.Madhunt {
 
                 if(doReset) {
                     roundState.oldDashes = ses.Dashes;
-                    roundState.oldFlags = ses.Flags;
-                    roundState.oldLevelFlags = ses.LevelFlags;
-                    roundState.oldDoNotLoad = ses.DoNotLoad;
-                    roundState.oldKeys = ses.Keys;
+                    roundState.oldFlags = new HashSet<string>(ses.Flags);
+                    roundState.oldLevelFlags = new HashSet<string>(ses.LevelFlags);
+                    roundState.oldDoNotLoad = new HashSet<EntityID>(ses.DoNotLoad);
+                    roundState.oldKeys = new HashSet<EntityID>(ses.Keys);
                     ses.Keys.Clear();
                     if(Celeste.Scene.Tracker.GetEntity<Player>() is Player player) player.Leader.LoseFollowers();
                 }


### PR DESCRIPTION
`ToHashSet` doesn't exist in the version of LINQ used by net452. This PR replaces prior calls to that method with the `new HashSet` constructor.