### PR TITLE
Rewrite fixes

### DIFF
--- a/Code/Madhunt/Logic/Round.cs
+++ b/Code/Madhunt/Logic/Round.cs
@@ -26,8 +26,8 @@ namespace Celeste.Mod.Madhunt {
             On.Celeste.Player.Die += DieHook;
             On.Celeste.Holdable.Pickup += PickupHook;
             
-            ghostPlayerCollisionHook = new Hook(typeof(Ghost).GetMethod(nameof(Ghost.OnPlayer)), typeof(MadhuntRound).GetMethod(nameof(GhostPlayerCollisionHook), BindingFlags.NonPublic | BindingFlags.Instance));
-            ghostNameRenderHook = new Hook(typeof(GhostNameTag).GetMethod(nameof(GhostNameTag.Render)), typeof(MadhuntRound).GetMethod(nameof(GhostNameTagRenderHook), BindingFlags.NonPublic | BindingFlags.Instance));
+            ghostPlayerCollisionHook = new Hook(typeof(Ghost).GetMethod(nameof(Ghost.OnPlayer)), typeof(MadhuntRound).GetMethod(nameof(GhostPlayerCollisionHook), BindingFlags.NonPublic | BindingFlags.Static));
+            ghostNameRenderHook = new Hook(typeof(GhostNameTag).GetMethod(nameof(GhostNameTag.Render)), typeof(MadhuntRound).GetMethod(nameof(GhostNameTagRenderHook), BindingFlags.NonPublic | BindingFlags.Static));
         }
 
         internal static void Uninit() {

--- a/Code/Madhunt/Logic/Round.cs
+++ b/Code/Madhunt/Logic/Round.cs
@@ -219,7 +219,10 @@ namespace Celeste.Mod.Madhunt {
             if(ses == null) return false;
             sesSnapshot = new SessionSnapshot(ses);
             ses.Keys.Clear();
-            if(MadhuntModule.Session != null) MadhuntModule.Session.WonLastRound = false;
+            ses.Inventory.DreamDash = true;
+            if(MadhuntModule.Session != null) {
+                MadhuntModule.Session.WonLastRound = false;
+            }
             spawnedInArena = false;
             arenaLevel = LoadLevel(ses, Settings.arenaArea, Settings.spawnLevel);
 
@@ -243,7 +246,10 @@ namespace Celeste.Mod.Madhunt {
                 Session ses = arenaLevel.Session;
                 sesSnapshot.Apply(ses);
                 ses.RespawnPoint = Settings.lobbySpawnPoint;
-                if(MadhuntModule.Session != null) MadhuntModule.Session.WonLastRound = isWinner;
+                ses.Inventory.DreamDash = isWinner;
+                if(MadhuntModule.Session != null) {
+                    MadhuntModule.Session.WonLastRound = isWinner;
+                }
                 LoadLevel(ses, Settings.lobbyArea, Settings.lobbyLevel);
 
                 arenaLevel = null;

--- a/Code/Madhunt/Logic/Round.cs
+++ b/Code/Madhunt/Logic/Round.cs
@@ -149,12 +149,11 @@ namespace Celeste.Mod.Madhunt {
         private static void GhostNameTagRenderHook(Action<GhostNameTag> orig, GhostNameTag nameTag) {
             //Don't render name tags of other roles (if disabled in the settings)
             MadhuntRound round = MadhuntModule.CurrentRound;
-            if(
-                round != null && round.Settings.hideNames &&
-                nameTag.Tracking is Ghost ghost && round.GetGhostState(ghost.PlayerInfo)?.State is var ghostState &&
-                ghostState?.role != round.State.role
-            ) return;
-
+            if(round != null && round.Settings.hideNames && nameTag.Tracking is Ghost ghost) {
+                PlayerState? ghostState = round.GetGhostState(ghost.PlayerInfo)?.State;
+                if(ghostState?.role != round.State.role) return;
+            }
+            
             orig(nameTag);
         }
 #endregion

--- a/Code/Madhunt/Logic/Round.cs
+++ b/Code/Madhunt/Logic/Round.cs
@@ -27,8 +27,8 @@ namespace Celeste.Mod.Madhunt {
             On.Celeste.Player.Die += DieHook;
             On.Celeste.Holdable.Pickup += PickupHook;
             
-            ghostPlayerCollisionHook = new Hook(typeof(Ghost).GetMethod(nameof(Ghost.OnPlayer)), typeof(MadhuntRound).GetMethod(nameof(GhostPlayerCollisionHook), BindingFlags.NonPublic | BindingFlags.Instance));
-            ghostNameRenderHook = new Hook(typeof(GhostNameTag).GetMethod(nameof(GhostNameTag.Render)), typeof(MadhuntRound).GetMethod(nameof(GhostNameTagRenderHook), BindingFlags.NonPublic | BindingFlags.Instance));
+            ghostPlayerCollisionHook = new Hook(typeof(Ghost).GetMethod(nameof(Ghost.OnPlayer)), typeof(MadhuntRound).GetMethod(nameof(GhostPlayerCollisionHook), BindingFlags.NonPublic | BindingFlags.Instance), this);
+            ghostNameRenderHook = new Hook(typeof(GhostNameTag).GetMethod(nameof(GhostNameTag.Render)), typeof(MadhuntRound).GetMethod(nameof(GhostNameTagRenderHook), BindingFlags.NonPublic | BindingFlags.Instance), this);
         }
 
         internal void Uninit() {

--- a/Code/Madhunt/Logic/Round.cs
+++ b/Code/Madhunt/Logic/Round.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
+
 using Microsoft.Xna.Framework;
 using MonoMod.RuntimeDetour;
 using Monocle;

--- a/Code/Madhunt/Logic/Round.cs
+++ b/Code/Madhunt/Logic/Round.cs
@@ -150,7 +150,7 @@ namespace Celeste.Mod.Madhunt {
 #endregion
 
         public readonly RoundSettings Settings;
-        private readonly CelesteNetClient netClient;
+        public readonly CelesteNetClient NetClient;
 
         private int playerSeed;
         private PlayerRole playerRole;
@@ -164,7 +164,7 @@ namespace Celeste.Mod.Madhunt {
 
         internal MadhuntRound(CelesteNetClient client, RoundSettings settings) {
             Settings = settings;
-            netClient = client;
+            NetClient = client;
 
             //Determine seed
             //Query the random number generator a random number of times
@@ -172,7 +172,7 @@ namespace Celeste.Mod.Madhunt {
             do { playerSeed = SEED_RNG.Next(int.MinValue, int.MaxValue); } while(numIter-- > 0);
 
             //Register handlers
-            netClient.Data.RegisterHandlersIn(this);
+            NetClient.Data.RegisterHandlersIn(this);
 
             //Start seed wait
             Logger.Log(MadhuntModule.Name, $"Starting Madhunt round {Settings.RoundID} with seed {playerSeed}");
@@ -190,12 +190,12 @@ namespace Celeste.Mod.Madhunt {
             if(Settings.initialSeekers > 0) {
                 PlayerRole = (GetGhostStates().Count(ghostState => {
                     int ghostSeed = ghostState.State.Value.seed;
-                    return ghostSeed > playerSeed || (ghostSeed == playerSeed && ghostState.Player.ID > netClient.PlayerInfo.ID);
+                    return ghostSeed > playerSeed || (ghostSeed == playerSeed && ghostState.Player.ID > NetClient.PlayerInfo.ID);
                 }) < Settings.initialSeekers) ? PlayerRole.SEEKER : PlayerRole.HIDER;
             } else {
                 PlayerRole = (GetGhostStates().Count(ghostState => {
                     int ghostSeed = ghostState.State.Value.seed;
-                    return ghostSeed > playerSeed || (ghostSeed == playerSeed && ghostState.Player.ID > netClient.PlayerInfo.ID);
+                    return ghostSeed > playerSeed || (ghostSeed == playerSeed && ghostState.Player.ID > NetClient.PlayerInfo.ID);
                 }) < -Settings.initialSeekers) ? PlayerRole.HIDER : PlayerRole.SEEKER;
             }
 
@@ -220,7 +220,7 @@ namespace Celeste.Mod.Madhunt {
             Logger.Log(MadhuntModule.Name, $"Stopping Madhunt round {Settings.RoundID} in role {PlayerRole}{(isWinner ? " as winner" : string.Empty)}");
 
             //Unregister handlers
-            netClient.Data.UnregisterHandlersIn(this);
+            NetClient.Data.UnregisterHandlersIn(this);
 
             //Return to lobby
             if(arenaLevel != null) {
@@ -285,14 +285,14 @@ namespace Celeste.Mod.Madhunt {
             if(string.IsNullOrEmpty(info.DisplayName)) return null;
 
             //Check ghost state
-            if(!netClient.Data.TryGetBoundRef<DataPlayerInfo, DataMadhuntStateUpdate>(info.ID, out DataMadhuntStateUpdate ghostState)) return null;
+            if(!NetClient.Data.TryGetBoundRef<DataPlayerInfo, DataMadhuntStateUpdate>(info.ID, out DataMadhuntStateUpdate ghostState)) return null;
             if(ghostState.State?.roundID != Settings.RoundID) return null;
             return ghostState;
         }
 
         public IEnumerable<DataMadhuntStateUpdate> GetGhostStates() =>
-            netClient.Data.GetRefs<DataPlayerInfo>()
-            .Where(i => i != netClient.PlayerInfo)
+            NetClient.Data.GetRefs<DataPlayerInfo>()
+            .Where(i => i != NetClient.PlayerInfo)
             .Select(i => GetGhostState(i))
             .Where(s => s != null)
         ;
@@ -309,8 +309,8 @@ namespace Celeste.Mod.Madhunt {
                 if(Celeste.Scene is Level lvl) UpdateFlags(lvl.Session);
 
                 //Send state update packet
-                netClient.Send<DataMadhuntStateUpdate>(new DataMadhuntStateUpdate() {
-                    Player = netClient.PlayerInfo,
+                NetClient.Send<DataMadhuntStateUpdate>(new DataMadhuntStateUpdate() {
+                    Player = NetClient.PlayerInfo,
                     State = State
                 });
 

--- a/Code/Madhunt/Logic/Round.cs
+++ b/Code/Madhunt/Logic/Round.cs
@@ -149,10 +149,11 @@ namespace Celeste.Mod.Madhunt {
         private static void GhostNameTagRenderHook(Action<GhostNameTag> orig, GhostNameTag nameTag) {
             //Don't render name tags of other roles (if disabled in the settings)
             MadhuntRound round = MadhuntModule.CurrentRound;
-            if(round != null && round.Settings.hideNames && 
-               nameTag.Tracking is Ghost ghost && round.GetGhostState(ghost.PlayerInfo)?.State is var ghostState &&
-               ghostState?.role == round.State.role
-              ) return;
+            if(
+                round != null && round.Settings.hideNames &&
+                nameTag.Tracking is Ghost ghost && round.GetGhostState(ghost.PlayerInfo)?.State is var ghostState &&
+                ghostState?.role != round.State.role
+            ) return;
 
             orig(nameTag);
         }

--- a/Code/Madhunt/Logic/RoundManager.cs
+++ b/Code/Madhunt/Logic/RoundManager.cs
@@ -155,6 +155,7 @@ namespace Celeste.Mod.Madhunt {
 
                 //Stop the round
                 curRound.Stop(curRound.PlayerRole == data.WinningRole);
+                curRound = null;
             });
         }
 

--- a/Code/Madhunt/Logic/RoundManager.cs
+++ b/Code/Madhunt/Logic/RoundManager.cs
@@ -60,7 +60,8 @@ namespace Celeste.Mod.Madhunt {
 
         private void ExitHook(Level lvl, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow) {
             //Exit the round (if we're in one)
-            if(MadhuntModule.CurrentRound != null) MadhuntModule.EndRound(null);
+            curRound?.Stop(returnToLobby: false);
+            curRound = null;
         }
 
         private void NetClientInit(CelesteNetClient client) {

--- a/Code/Madhunt/Logic/RoundManager.cs
+++ b/Code/Madhunt/Logic/RoundManager.cs
@@ -37,6 +37,9 @@ namespace Celeste.Mod.Madhunt {
             } else {
                 disposeEvt.AddEventHandler(null, netDisposeHook = (Action<object>) (_ => NetClientDisposed()));
             }
+            
+            Everest.Events.Level.OnLoadLevel += LevelLoadHook;
+            Everest.Events.Level.OnExit += ExitHook;
         }
 
         protected override void Dispose(bool disposing) {
@@ -45,6 +48,19 @@ namespace Celeste.Mod.Madhunt {
             //Remove hooks
             if(netDisposeHook != null) typeof(CelesteNetClientContext).GetEvent("OnDispose").RemoveEventHandler(null, netDisposeHook);
             netDisposeHook = null;
+            
+            Everest.Events.Level.OnLoadLevel -= LevelLoadHook;
+            Everest.Events.Level.OnExit -= ExitHook;
+        }
+        
+        private void LevelLoadHook(Level lvl, Player.IntroTypes intro, bool fromLoader) {
+            //Disable save and quit when in a round
+            if(MadhuntModule.CurrentRound != null) lvl.SaveQuitDisabled = true;
+        }
+
+        private void ExitHook(Level lvl, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow) {
+            //Exit the round (if we're in one)
+            if(MadhuntModule.CurrentRound != null) MadhuntModule.EndRound(null);
         }
 
         private void NetClientInit(CelesteNetClient client) {

--- a/Code/Madhunt/Logic/RoundManager.cs
+++ b/Code/Madhunt/Logic/RoundManager.cs
@@ -55,6 +55,7 @@ namespace Celeste.Mod.Madhunt {
         private void NetClientDisposed() {
             //Stop current round (if we have one)
             curRound?.Stop();
+            curRound = null;
         }
 
         public override void Update(GameTime gameTime) {
@@ -103,7 +104,11 @@ namespace Celeste.Mod.Madhunt {
     
         public void EndRound(PlayerRole? winnerRole) {
             if(curRound == null) return;
-            curRound.Stop(curRound.PlayerRole == winnerRole);
+            curRound.NetClient.SendAndHandle(new DataMadhuntRoundEnd() {
+                EndPlayer = curRound.NetClient.PlayerInfo,
+                RoundID = curRound.Settings.RoundID,
+                WinningRole = winnerRole
+            });
         }
 
         public bool IsRoundActive(string id) =>

--- a/Code/Madhunt/Module.cs
+++ b/Code/Madhunt/Module.cs
@@ -19,8 +19,6 @@ namespace Celeste.Mod.Madhunt {
 
         public override void Load() {
             //Initialize hooks
-            MadhuntRound.Init();
-
             unlockedAreasHook = new Hook(typeof(LevelSetStats).GetProperty("UnlockedAreas").GetGetMethod(), (Func<Func<LevelSetStats, int>, LevelSetStats, int>) ((orig, stats) => {
                 if(stats.Name == Name) return stats.MaxArea;
                 return orig(stats);
@@ -42,7 +40,6 @@ namespace Celeste.Mod.Madhunt {
             roundManager.Dispose();
 
             unlockedAreasHook.Dispose();
-            MadhuntRound.Uninit();
         }
 
         public bool VerifyRoundStart(DataMadhuntRoundStart startPacket) {

--- a/Code/Madhunt/Module.cs
+++ b/Code/Madhunt/Module.cs
@@ -19,6 +19,8 @@ namespace Celeste.Mod.Madhunt {
 
         public override void Load() {
             //Initialize hooks
+            MadhuntRound.Init();
+            
             unlockedAreasHook = new Hook(typeof(LevelSetStats).GetProperty("UnlockedAreas").GetGetMethod(), (Func<Func<LevelSetStats, int>, LevelSetStats, int>) ((orig, stats) => {
                 if(stats.Name == Name) return stats.MaxArea;
                 return orig(stats);
@@ -40,6 +42,7 @@ namespace Celeste.Mod.Madhunt {
             roundManager.Dispose();
 
             unlockedAreasHook.Dispose();
+            MadhuntRound.Uninit();
         }
 
         public bool VerifyRoundStart(DataMadhuntRoundStart startPacket) {

--- a/Code/Madhunt/SessionSnapshot.cs
+++ b/Code/Madhunt/SessionSnapshot.cs
@@ -43,6 +43,7 @@ namespace Celeste.Mod.Madhunt {
             counters = ses.Counters.Copy(c => c.Copy());
             doNotLoad = ses.DoNotLoad.Copy();
             keys = ses.Keys.Copy();
+            summitGems = ses.SummitGems.Copy();
         }
 
         public void Apply(Session ses) {
@@ -59,6 +60,7 @@ namespace Celeste.Mod.Madhunt {
             ses.Counters = counters.Copy(c => c.Copy());
             ses.DoNotLoad = doNotLoad.Copy();
             ses.Keys = keys.Copy();
+            ses.SummitGems = summitGems.Copy();
         }
     }
 }


### PR DESCRIPTION
Fixes some bugs left from the rewrite https://github.com/Popax21/Madhunt/commit/e65b419a89f92ed123d24244fcaaa57b525cc9db:
- Seekers kill hiders on collision now
- The hider win heart properly ends the round and takes the seeker out of badeline mode

Some bugs that are still left, that I don't know how to fix:
- Non-vanilla `Session` data will not be backed up
- "Return To Map" won't properly end the round, leaving the seeker in badeline mode and preventing further games from starting
- Even with the `GhostNameTagRenderHook`, nametags of players on the opposite team are still visible

I'm not sure about my usage of `Stop`/`Uninit`; I'm worried about running into double-free issues, as well as worried about the separation of ownership (i.e. `curRound = null` being separate from `curRound.Uninit();`). A second pair of eyes on this would be nice.